### PR TITLE
Adds support for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 2.1
+  - 2.2
+script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "rack", "1.5.1"
+gem "chef"
+gem "rspec"
+gem "chefspec"
+gem "berkshelf"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dokku
 
+[![Build Status](https://travis-ci.org/nickcharlton/dokku-cookbook.svg?branch=master)](https://travis-ci.org/nickcharlton/dokku-cookbook)
+
 This is a rebuild of the existing [chef-dokku][] cookbook, switching to a
 direct package install and providing Lightweight Resource Providers (LWRPs) for
 managing apps and it's components.


### PR DESCRIPTION
This also provides a Gemfile, which Travis will need to run builds. It's pinned to Rack 1.5.1 because otherwise it's failing.