### PR TITLE
Bring the nginx configuration file into Chef.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,24 @@ managing apps and it's components.
 * `dokku::plugins`: Manages plugins from attributes.
 * `dokku::apps`: Manages apps from attributes.
 
+### Attributes
+
+#### default
+
+* `node["dokku"]["domain"]`: The domain for Dokku to serve under.
+* `node["dokku"]["ssh_keys"]`: A list of ssh keys to allow for deployment.
+* `node["dokku"]["plugins"]`: A list of plugins to manage.
+* `node["dokku"]["apps"]`: A list of apps to manage.
+
+These optional settings can be overridden to customise the default Nginx
+configuration (which is used for all apps):
+
+* `node["dokku"]["nginx"]["server_tokens"]`: Defaults to `off`.
+* `node["dokku"]["nginx"]["ssl_session_cache"]`: Defaults to `shared:SSL:20m`.
+* `node["dokku"]["nginx"]["ssl_session_timeout"]`: Defaults to `10m`.
+* `node["dokku"]["nginx"]["ssl_ciphers"]`: Defaults to
+  `EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5`
+
 ### LWRPs
 
 #### `ssh_key`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,3 +8,9 @@ default["dokku"]["domain"] = nil
 default["dokku"]["ssh_keys"] = []
 default["dokku"]["plugins"] = []
 default["dokku"]["apps"] = []
+
+default["dokku"]["nginx"]["server_tokens"] = "off"
+default["dokku"]["nginx"]["ssl_session_cache"] = "shared:SSL:20m"
+default["dokku"]["nginx"]["ssl_session_timeout"] = "10m"
+default["dokku"]["nginx"]["ssl_ciphers"] = "EECDH+AES128:RSA+AES128:" \
+  "EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -35,3 +35,9 @@ end
 file "/home/dokku/VHOST" do
   content node["dokku"]["domain"] || node["fqdn"]
 end
+
+template "/etc/nginx/conf.d/dokku.conf" do
+  source "nginx.conf.erb"
+
+  notifies :restart, "service[nginx]", :delayed
+end

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -48,5 +48,14 @@ describe "dokku::install" do
     it "creates the domain file" do
       expect(chef_run).to create_file("/home/dokku/VHOST")
     end
+
+    it "configures the dokku nginx config file" do
+      template_file = "/etc/nginx/conf.d/dokku.conf"
+
+      expect(chef_run).to create_template(template_file)
+
+      resource = chef_run.template(template_file)
+      expect(resource).to notify("service[nginx]").to(:restart).delayed
+    end
   end
 end

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -1,0 +1,8 @@
+include /home/dokku/*/nginx.conf;
+
+server_tokens <%= node["dokku"]["nginx"]["server_tokens"] %>;
+
+ssl_session_cache <%= node["dokku"]["nginx"]["ssl_session_cache"] %>;
+ssl_session_timeout <%= node["dokku"]["nginx"]["ssl_session_timeout"] %>;
+
+ssl_ciphers <%= node["dokku"]["nginx"]["ssl_ciphers"] %>;

--- a/test/integration/default/serverspec/install_spec.rb
+++ b/test/integration/default/serverspec/install_spec.rb
@@ -24,4 +24,11 @@ describe "dokku::install" do
     expect(source_file).to exist
     expect(source_file).to contain("dokku.me")
   end
+
+  it "configures dokku nginx config" do
+    config_file = file("/etc/nginx/conf.d/dokku.conf")
+
+    expect(config_file).to contain("server_tokens")
+    expect(config_file).to contain("ssl_ciphers")
+  end
 end


### PR DESCRIPTION
This allows us to configure the settings for nginx (as used by Dokku globally)
along with the rest of the configuration.

It's also necessary for configuring global SSL certificates (in a not completely
inflexible manner).