### PR TITLE
Install specific package versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is a Chef cookbook which provides the ability to install and configure
 [dokku][]. It provides a set of recipes and Lightweight Resource Providers
 (LWRPs) for managing apps and it's components.
 
+It's [pinned][] against a [specific version of dokku][dokku_releases] to protect
+your installation against being accidentally broken. This marks a `hold`
+against the installed packages.
+
 ## Usage
 
 ### Recipes
@@ -133,6 +137,8 @@ chef exec kitchen test
 Copyright (c) Nick Charlton 2015. MIT licensed.
 
 [dokku]: https://github.com/dokku/dokku
+[pinned]: https://github.com/nickcharlton/dokku-cookbook/blob/master/attributes/default.rb#L7
+[dokku_releases]: https://github.com/dokku/dokku/releases
 [certificate cookbook]: https://github.com/atomic-penguin/cookbook-certificate
 [plugins]: http://dokku.viewdocs.io/dokku/plugins/
 [ChefSpec]: https://docs.chef.io/chefspec.html

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,11 @@
 #
 # Copyright (c) 2015 Nick Charlton, MIT licensed.
 
+default["dokku"]["package"]["dokku"]["version"] = "0.4.14"
+default["dokku"]["package"]["herokuish"]["version"] = "0.3.8"
+default["dokku"]["package"]["sshcommand"]["version"] = "0.1.0"
+default["dokku"]["package"]["plugn"]["version"] = "0.2.1"
+
 default["dokku"]["domain"] = nil
 default["dokku"]["ssh_keys"] = []
 default["dokku"]["plugins"] = []

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -23,6 +23,11 @@ execute "install-dokku-plugin-core-dependencies" do
 end
 
 %w(herokuish sshcommand plugn dokku).each do |pkg|
+  execute "hold-dependency-#{pkg}" do
+    command "apt-mark hold #{pkg}"
+    action :nothing
+  end
+
   package pkg do
     version node["dokku"]["package"][pkg]["version"]
 
@@ -31,6 +36,8 @@ end
                "execute[install-dokku-plugin-core-dependencies]",
                :immediately
     end
+
+    notifies :run, "execute[hold-dependency-#{pkg}]", :immediately
   end
 end
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -22,8 +22,16 @@ execute "install-dokku-plugin-core-dependencies" do
   action :nothing
 end
 
-package "dokku" do
-  notifies :run, "execute[install-dokku-plugin-core-dependencies]", :immediately
+%w(herokuish sshcommand plugn dokku).each do |pkg|
+  package pkg do
+    version node["dokku"]["package"][pkg]["version"]
+
+    if pkg == "dokku"
+      notifies :run,
+               "execute[install-dokku-plugin-core-dependencies]",
+               :immediately
+    end
+  end
 end
 
 # otherwise, it gets redefined when the core dependencies are installed

--- a/spec/unit/recipes/apps_spec.rb
+++ b/spec/unit/recipes/apps_spec.rb
@@ -49,12 +49,8 @@ describe "dokku::apps" do
 
     it "manages apps using attributes" do
       expect(chef_run).to create_dokku_app("test-addition")
-
-      expect(chef_run).to create_dokku_app("test-rename")
       expect(chef_run).to rename_dokku_app("test-rename").with(
         new_name: "renamed")
-
-      expect(chef_run).to create_dokku_app("test-destroy")
       expect(chef_run).to destroy_dokku_app("test-destroy")
     end
   end

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -28,7 +28,7 @@ describe "dokku::install" do
     end
 
     it "installs dokku" do
-      expect(chef_run).to install_package "dokku"
+      expect(chef_run).to install_package("dokku").with(version: "0.4.14")
     end
 
     it "installs dokku plugin core dependencies" do

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -31,6 +31,13 @@ describe "dokku::install" do
       expect(chef_run).to install_package("dokku").with(version: "0.4.14")
     end
 
+    it "marks a hold on the dokku package" do
+      resource = chef_run.package("dokku")
+
+      expect(resource).to notify(
+        "execute[hold-dependency-dokku]").to(:run).immediately
+    end
+
     it "installs dokku plugin core dependencies" do
       resource = chef_run.package("dokku")
 

--- a/test/integration/default/serverspec/install_spec.rb
+++ b/test/integration/default/serverspec/install_spec.rb
@@ -15,7 +15,7 @@ describe "dokku::install" do
   end
 
   it "installs dokku" do
-    expect(package("dokku")).to be_installed
+    expect(package("dokku")).to be_installed.by("apt").with_version("0.4.14")
   end
 
   it "sets the domain for dokku" do

--- a/test/integration/default/serverspec/install_spec.rb
+++ b/test/integration/default/serverspec/install_spec.rb
@@ -18,6 +18,12 @@ describe "dokku::install" do
     expect(package("dokku")).to be_installed.by("apt").with_version("0.4.14")
   end
 
+  it "marks a hold on the dokku package" do
+    cmd = command("dpkg --get-selections dokku | grep hold")
+
+    expect(cmd.exit_status).to eq(0)
+  end
+
   it "sets the domain for dokku" do
     source_file = file("/home/dokku/VHOST")
 


### PR DESCRIPTION
Future versions (0.5.0) and up of dokku bring in a set of breaking changes. This is expected to keep happening.

This installs specific packages and places a hold on them so that the user doesn't accidentally break their system.