### PR TITLE
Replace the nginx dependency with a custom recipe.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,6 @@ version "1.2.0"
 depends "apt", "~> 2.9"
 depends "docker", "~> 2.0"
 depends "packagecloud", "~> 0.1"
-depends "nginx", "~> 2.7"
 depends "openssl", "~> 4.4"
 
 recipe "default", "Triggers install cookbooks and provides the LWRP."

--- a/providers/app.rb
+++ b/providers/app.rb
@@ -19,7 +19,8 @@ end
 
 action :destroy do
   execute "destroying app: #{new_resource.name}" do
-    command "dokku --force apps:destroy #{new_resource.name}"
+    command "dokku --force apps:destroy #{new_resource.name} " \
+     "| grep 'Destroying #{new_resource.name}'"
 
     only_if { FileTest.directory?("/home/dokku/#{new_resource.name}") }
   end

--- a/recipes/_nginx.rb
+++ b/recipes/_nginx.rb
@@ -1,0 +1,12 @@
+#
+# Cookbook Name:: dokku
+# Recipe:: _nginx
+#
+# Copyright (c) 2015 Nick Charlton, MIT licensed.
+
+package "nginx"
+
+service "nginx" do
+  supports status: true, restart: true, reload: true
+  action :start
+end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2015 Nick Charlton, MIT licensed.
 
-include_recipe "nginx"
+include_recipe "dokku::_nginx"
 include_recipe "openssl"
 
 package "apt-transport-https"
@@ -39,13 +39,6 @@ end
 
     notifies :run, "execute[hold-dependency-#{pkg}]", :immediately
   end
-end
-
-# otherwise, it gets redefined when the core dependencies are installed
-file "/etc/nginx/conf.d/server_names_hash_bucket_size.conf" do
-  action :delete
-
-  notifies :restart, "service[nginx]", :delayed
 end
 
 file "/home/dokku/VHOST" do

--- a/recipes/plugins.rb
+++ b/recipes/plugins.rb
@@ -4,8 +4,6 @@
 #
 # Copyright (c) 2015 Nick Charlton, MIT licensed.
 
-include_recipe "nginx"
-
 plugins = node["dokku"]["plugins"]
 
 plugins.each do |plugin|
@@ -13,12 +11,4 @@ plugins.each do |plugin|
     url plugin["url"]
     action plugin.fetch("action", "install").to_sym
   end
-end
-
-# installing plugins will cause the same problem as with the install recipe:
-# it gets redefined when the core dependencies are installed
-file "/etc/nginx/conf.d/server_names_hash_bucket_size.conf" do
-  action :delete
-
-  notifies :restart, "service[nginx]", :delayed
 end

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -18,7 +18,7 @@ describe "dokku::install" do
     end
 
     it "installs the required dependencies" do
-      expect(chef_run).to include_recipe "nginx"
+      expect(chef_run).to include_recipe("dokku::_nginx")
       expect(chef_run).to install_package "apt-transport-https"
       expect(chef_run).to start_docker_service "default"
     end
@@ -43,13 +43,6 @@ describe "dokku::install" do
 
       expect(resource).to notify(
         "execute[install-dokku-plugin-core-dependencies]").to(:run).immediately
-    end
-
-    it "removes conflicing default configuration" do
-      resource = chef_run.file(
-        "/etc/nginx/conf.d/server_names_hash_bucket_size.conf")
-
-      expect(resource).to notify("service[nginx]").to(:restart).delayed
     end
 
     it "creates the domain file" do

--- a/spec/unit/recipes/nginx_spec.rb
+++ b/spec/unit/recipes/nginx_spec.rb
@@ -1,0 +1,28 @@
+#
+# Cookbook Name:: dokku
+# Spec:: _nginx
+#
+# Copyright (c) 2015 Nick Charlton, MIT licensed.
+
+require "spec_helper"
+
+describe "dokku::_nginx" do
+  context "when all attributes are default, on an unspecified platform" do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    before do
+      stub_command("which nginx").and_return("/usr/bin/nginx")
+    end
+
+    it "installs nginx" do
+      expect(chef_run).to install_package("nginx")
+    end
+
+    it "starts nginx" do
+      expect(chef_run).to start_service("nginx")
+    end
+  end
+end

--- a/spec/unit/recipes/plugins_spec.rb
+++ b/spec/unit/recipes/plugins_spec.rb
@@ -66,12 +66,5 @@ describe "dokku::plugins" do
       expect(chef_run).to uninstall_dokku_plugin(
         "mongo").with(url: "https://github.com/dokku/dokku-mongo.git")
     end
-
-    it "removes conflicing default configuration" do
-      resource = chef_run.file(
-        "/etc/nginx/conf.d/server_names_hash_bucket_size.conf")
-
-      expect(resource).to notify("service[nginx]").to(:restart).delayed
-    end
   end
 end

--- a/test/integration/default/serverspec/nginx_spec.rb
+++ b/test/integration/default/serverspec/nginx_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe "dokku::_nginx" do
+  it "installs nginx" do
+    expect(package("nginx")).to be_installed
+  end
+
+  it "starts nginx" do
+    expect(service("nginx")).to be_running
+  end
+end


### PR DESCRIPTION
This replaces the dependency on the `nginx` cookbook with a _very_ simple recipe.

This is mostly to solve some odd bugs that have been showing up with plugins.