### PR TITLE
Release package hold

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -28,8 +28,15 @@ end
     action :nothing
   end
 
+  execute "unhold-dependency-#{pkg}" do
+    command "apt-mark unhold #{pkg}"
+    action :nothing
+  end
+
   package pkg do
     version node["dokku"]["package"][pkg]["version"]
+
+    notifies :run, "execute[unhold-dependency-#{pkg}]", :immediately
 
     if pkg == "dokku"
       notifies :run,

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -27,6 +27,13 @@ describe "dokku::install" do
       expect(chef_run).to create_packagecloud_repo "dokku/dokku"
     end
 
+    it "releases a hold on the dokku package" do
+      resource = chef_run.package("dokku")
+
+      expect(resource).to notify(
+        "execute[unhold-dependency-dokku]").to(:run).immediately
+    end
+
     it "installs dokku" do
       expect(chef_run).to install_package("dokku").with(version: "0.12.13")
     end


### PR DESCRIPTION
Thank you for this cookbook, it's been very helpful as a starting point for some server configuration I've been doing.

I just attempted to leverage it to upgrade my existing Dokku install though, and ran into the following error:

```STDERR: E: Held packages were changed and -y was used without --allow-change-held-packages.```

Looking through the codebase, I noticed that after the packages are installed a hold is placed on them. My understanding is that we would need to release that hold prior to attempting any further modification of the packages, which is why I've put together this PR to do so.

While making those changes, I also updated the default version numbers since it's progressed quite a while since the last update, and added test support for Ubuntu 18.04.

I hope this helps and is a welcome addition, but please let me know if you have any reservations or feedback at all and I'll be happy to address.