### PR TITLE
Update Travis to Use Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: required
-dist: trusty
+dist: xenial
 
 addons:
   apt:
     sources:
-      - chef-current-trusty
+      - chef-stable-xenial
     packages:
       - chefdk
       - docker-ce

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 
 services: docker
 
-install: chef exec bundle
+install: CHEF_LICENSE="accept" chef exec bundle
 
 # Ensure we make ChefDK's Ruby the default
 before_script:


### PR DESCRIPTION
I'm flying a bit blind here but I took a look at the Travis CI error and it seemed surprising and unrelated to the recent updates:

```
Installing APT Packages
0.35s$ sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install chefdk docker-ce
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package chefdk
apt-get.diagnostics
apt-get install failed
The command "sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install chefdk docker-ce" failed and exited with 100 during .
```

Given that it couldn't find `chefdk`, my best guess is that the problem is using such an old version of Ubuntu and the package lists being archived or something.

I'm not aware of a way to test whether this fixes the Travis issue or not, but I've updated it to use Xenial (which is actually in alignment with the version the chef tests run against locally) and switched it from Chef Current to Chef Stable since Chef doesn't make any guarantees about Current. I figured that'd be more dependable for testing but I can revert if desired.

I welcome any thoughts or feedback you have regarding this, hopefully my guesswork here is on the right track.